### PR TITLE
Fix: Resolve multiple Angular & PrimeNG compilation errors

### DIFF
--- a/WkTecnology.Presentation/WkTecnology.Portifolio/angular.json
+++ b/WkTecnology.Presentation/WkTecnology.Portifolio/angular.json
@@ -37,7 +37,7 @@
               }
             ],
             "styles": [
-              "node_modules/primeng/resources/themes/saga-blue/theme.css",
+              "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
               "node_modules/primeng/resources/primeng.min.css",
               "node_modules/primeicons/primeicons.css",
               "src/styles.css"

--- a/WkTecnology.Presentation/WkTecnology.Portifolio/src/app/features/categories/components/category-form/category-form.component.ts
+++ b/WkTecnology.Presentation/WkTecnology.Portifolio/src/app/features/categories/components/category-form/category-form.component.ts
@@ -1,16 +1,39 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CategoryService } from '../../../../core/services/category.service';
 import { Category } from '../../../../core/models/category.model';
-import { UpdateCategoryPayload } from '../../../../core/models/category-payloads.model'; // Importar UpdateCategoryPayload
+import { UpdateCategoryPayload } from '../../../../core/models/category-payloads.model';
 import { MessageService } from 'primeng/api';
+
+// PrimeNG Modules - Experimental direct import for non-standalone component
+import { ToastModule } from 'primeng/toast';
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { InputTextareaModule } from 'primeng/inputtextarea';
+import { InputSwitchModule } from 'primeng/inputswitch';
+import { ButtonModule } from 'primeng/button';
+// RippleModule might be needed for pRipple on button, usually comes with ButtonModule or imported separately
+import { RippleModule } from 'primeng/ripple';
+
 
 @Component({
   selector: 'app-category-form',
   templateUrl: './category-form.component.html',
   styleUrls: ['./category-form.component.css'],
-  providers: [MessageService] // Adicionar MessageService se não estiver globalmente
+  providers: [MessageService],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    ToastModule,
+    CardModule,
+    InputTextModule,
+    InputTextareaModule,
+    InputSwitchModule,
+    ButtonModule,
+    RippleModule // Added for pRipple
+  ] // This is for standalone components. Angular might error here.
 })
 export class CategoryFormComponent implements OnInit {
   categoryForm!: FormGroup;
@@ -102,7 +125,11 @@ export class CategoryFormComponent implements OnInit {
         }
       });
     } else {
-      this.categoryService.createCategory(categoryPayload).subscribe({
+      // Use formData, which is this.categoryForm.value
+      // Ensure the structure of formData matches what createCategory expects.
+      // If CreateCategoryPayload is defined and different, map formData to it.
+      // Assuming createCategory can take an object like { name, description, isActive }
+      this.categoryService.createCategory(formData).subscribe({
         next: () => {
           this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Categoria criada!' });
           this.isLoading = false;

--- a/WkTecnology.Presentation/WkTecnology.Portifolio/src/app/features/categories/components/category-list/category-list.component.html
+++ b/WkTecnology.Presentation/WkTecnology.Portifolio/src/app/features/categories/components/category-list/category-list.component.html
@@ -33,7 +33,7 @@
         <!-- Exemplo de input de filtro global para a tabela, pode ser melhorado -->
         <span class="p-input-icon-left ml-auto">
           <i class="pi pi-search"></i>
-          <input pInputText type="text" (input)="dt.filterGlobal($event.target.value, 'contains')" placeholder="Pesquisar..." />
+          <input pInputText type="text" (input)="dt.filterGlobal(($event.target as HTMLInputElement).value, 'contains')" placeholder="Pesquisar..." />
         </span>
       </div>
     </ng-template>

--- a/WkTecnology.Presentation/WkTecnology.Portifolio/src/app/features/categories/components/category-list/category-list.component.ts
+++ b/WkTecnology.Presentation/WkTecnology.Portifolio/src/app/features/categories/components/category-list/category-list.component.ts
@@ -2,13 +2,39 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Category } from '../../../../core/models/category.model';
 import { CategoryService } from '../../../../core/services/category.service';
-import { ConfirmationService, MessageService } from 'primeng/api'; // Para diálogos de confirmação e mensagens
+import { ConfirmationService, MessageService } from 'primeng/api';
+
+// Angular Common Module
+import { CommonModule } from '@angular/common';
+
+// PrimeNG Modules - Experimental direct import
+import { ToastModule } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ToolbarModule } from 'primeng/toolbar';
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonModule } from 'primeng/button';
+import { RippleModule } from 'primeng/ripple'; // For pRipple
+import { TooltipModule } from 'primeng/tooltip'; // For pTooltip
 
 @Component({
   selector: 'app-category-list',
   templateUrl: './category-list.component.html',
   styleUrls: ['./category-list.component.css'],
-  providers: [ConfirmationService, MessageService] // Adicionar seletor de confirmação e mensagens
+  providers: [ConfirmationService, MessageService],
+  imports: [ // Experimental for non-standalone component
+    CommonModule,
+    ToastModule,
+    ConfirmDialogModule,
+    ToolbarModule,
+    TableModule,
+    TagModule,
+    InputTextModule,
+    ButtonModule,
+    RippleModule,
+    TooltipModule
+  ]
 })
 export class CategoryListComponent implements OnInit {
   categories: Category[] = [];


### PR DESCRIPTION
- Fixed TS2304: Replaced undefined 'categoryPayload' with 'formData' in CategoryFormComponent.
- Fixed NG9/NG1: Corrected table filter input event in CategoryListComponent to use '(event.target as HTMLInputElement).value'.
- Aligned PrimeNG theme CSS path in angular.json to 'lara-light-blue/theme.css' as per error messages. Actual file availability in node_modules needs verification.

- Experimental: Attempted to resolve NG8001, NG8002, NG8103 errors (unknown elements/directives like *ngIf, PrimeNG components) by adding CommonModule, ReactiveFormsModule, and required PrimeNG modules directly to the @Component.imports array for CategoryFormComponent and CategoryListComponent. This is unconventional for non-standalone components as their NgModule ('CategoriesModule') already correctly imports these. These errors may persist if the root cause is environmental (node_modules, cache, versions).